### PR TITLE
use corev1 podspec directly instead of using kserve's copy

### DIFF
--- a/pkg/apis/serving/v1beta1/explainer.go
+++ b/pkg/apis/serving/v1beta1/explainer.go
@@ -33,7 +33,7 @@ type ExplainerSpec struct {
 	// The field PodSpec.Containers is mutually exclusive with other explainers (i.e. Alibi).
 	// 2) Users may choose to provide a Explainer (i.e. Alibi) and specify PodSpec
 	// overrides in the PodSpec. They must not provide PodSpec.Containers in this case.
-	PodSpec `json:",inline"`
+	v1.PodSpec `json:",inline"`
 	// Component extension defines the deployment configurations for explainer
 	ComponentExtensionSpec `json:",inline"`
 }

--- a/pkg/apis/serving/v1beta1/explainer_custom.go
+++ b/pkg/apis/serving/v1beta1/explainer_custom.go
@@ -33,7 +33,7 @@ type CustomExplainer struct {
 
 var _ ComponentImplementation = &CustomExplainer{}
 
-func NewCustomExplainer(podSpec *PodSpec) *CustomExplainer {
+func NewCustomExplainer(podSpec *v1.PodSpec) *CustomExplainer {
 	return &CustomExplainer{PodSpec: v1.PodSpec(*podSpec)}
 }
 

--- a/pkg/apis/serving/v1beta1/predictor.go
+++ b/pkg/apis/serving/v1beta1/predictor.go
@@ -59,7 +59,7 @@ type PredictorSpec struct {
 	// The field PodSpec.Containers is mutually exclusive with other predictors (i.e. TFServing). <br />
 	// 2) Provide a predictor (i.e. TFServing) and specify PodSpec
 	// overrides, you must not provide PodSpec.Containers in this case. <br />
-	PodSpec `json:",inline"`
+	v1.PodSpec `json:",inline"`
 	// Component extension defines the deployment configurations for a predictor
 	ComponentExtensionSpec `json:",inline"`
 }

--- a/pkg/apis/serving/v1beta1/predictor_custom.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom.go
@@ -36,7 +36,7 @@ var (
 	_ PredictorImplementation = &CustomPredictor{}
 )
 
-func NewCustomPredictor(podSpec *PodSpec) *CustomPredictor {
+func NewCustomPredictor(podSpec *v1.PodSpec) *CustomPredictor {
 	return &CustomPredictor{PodSpec: v1.PodSpec(*podSpec)}
 }
 

--- a/pkg/apis/serving/v1beta1/transformer.go
+++ b/pkg/apis/serving/v1beta1/transformer.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package v1beta1
 
+import v1 "k8s.io/api/core/v1"
+
 // TransformerSpec defines transformer service for pre/post processing
 type TransformerSpec struct {
 	// This spec is dual purpose. <br />
@@ -23,7 +25,7 @@ type TransformerSpec struct {
 	// The field PodSpec.Containers is mutually exclusive with other transformers. <br />
 	// 2) Provide a transformer and specify PodSpec
 	// overrides, you must not provide PodSpec.Containers in this case. <br />
-	PodSpec `json:",inline"`
+	v1.PodSpec `json:",inline"`
 	// Component extension defines the deployment configurations for a transformer
 	ComponentExtensionSpec `json:",inline"`
 }

--- a/pkg/apis/serving/v1beta1/transformer_custom.go
+++ b/pkg/apis/serving/v1beta1/transformer_custom.go
@@ -39,7 +39,7 @@ var (
 
 var _ ComponentImplementation = &CustomTransformer{}
 
-func NewCustomTransformer(podSpec *PodSpec) *CustomTransformer {
+func NewCustomTransformer(podSpec *v1.PodSpec) *CustomTransformer {
 	return &CustomTransformer{PodSpec: v1.PodSpec(*podSpec)}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
